### PR TITLE
Add OpenSSH client support for Git SSH remotes

### DIFF
--- a/ha_opencode/CHANGELOG.md
+++ b/ha_opencode/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Git remotes using SSH now work out of the box with the bundled OpenSSH client tools.
 - Documented the persistent `/config/.opencode` locations for user-owned skills and agents, including editor access and restart behavior.
 - ESPHome agents can now read, validate, create, and safely update Device Builder YAML through its native WebSocket API, with preview-first writes, stale-source checks, and post-write verification.
 - ESPHome management now covers device lifecycle, adoption, board and metadata discovery, YAML search and includes, write-only secret/key workflows, version history, bounded logs, managed firmware jobs, build cleanup, serial provisioning, and remote-build pairing.

--- a/ha_opencode/Dockerfile
+++ b/ha_opencode/Dockerfile
@@ -51,6 +51,7 @@ ENV ADDON_CHANNEL=${ADDON_CHANNEL}
 # Install system dependencies in a single layer
 # - nodejs/npm: Required for OpenCode
 # - git: Required by OpenCode for version control operations
+# - openssh-client: Required by Git when remotes use SSH
 # - jq: JSON processing for helper scripts
 # - curl/ca-certificates: For downloading ttyd
 # - bzip2: Required by system tar to extract OpenChamber voice models
@@ -67,6 +68,7 @@ RUN apt-get update \
         git \
         jq \
         nodejs \
+        openssh-client \
         npm \
         procps \
         python3 \

--- a/ha_opencode/Dockerfile
+++ b/ha_opencode/Dockerfile
@@ -51,7 +51,7 @@ ENV ADDON_CHANNEL=${ADDON_CHANNEL}
 # Install system dependencies in a single layer
 # - nodejs/npm: Required for OpenCode
 # - git: Required by OpenCode for version control operations
-# - openssh-client: Required by Git when remotes use SSH
+# - openssh-client: Provides ssh, ssh-keygen, and ssh-keyscan for Git SSH remotes
 # - jq: JSON processing for helper scripts
 # - curl/ca-certificates: For downloading ttyd
 # - bzip2: Required by system tar to extract OpenChamber voice models
@@ -74,6 +74,9 @@ RUN apt-get update \
         python3 \
         python3-venv \
         tmux \
+    && command -v ssh >/dev/null \
+    && command -v ssh-keygen >/dev/null \
+    && command -v ssh-keyscan >/dev/null \
     && rm -rf /var/lib/apt/lists/*
 
 # Chromium path for puppeteer-core (used by screenshot MCP tool)

--- a/ha_opencode/test/runtime-contract.test.js
+++ b/ha_opencode/test/runtime-contract.test.js
@@ -79,6 +79,13 @@ describe(`${CHANNEL} runtime pin`, () => {
       /opencode_certified_version\(\)/,
     );
   });
+
+  it("ships OpenSSH client tools for Git SSH remotes", () => {
+    assert.match(dockerfile, /^\s*openssh-client \\/m);
+    for (const command of ["ssh", "ssh-keygen", "ssh-keyscan"]) {
+      assert.match(dockerfile, new RegExp(`command -v ${command} >/dev/null`));
+    }
+  });
 });
 
 describe(`${CHANNEL} bundled runtime precedence`, () => {

--- a/ha_opencode_beta/CHANGELOG.md
+++ b/ha_opencode_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1b2
+
+- Git remotes using SSH now work out of the box with the bundled OpenSSH client tools.
+
 ## 2.5.1b1
 
 - ESPHome management now covers device lifecycle, adoption, board and metadata discovery, YAML search and includes, write-only secret/key workflows, version history, bounded logs, managed firmware jobs, build cleanup, serial provisioning, and remote-build pairing.

--- a/ha_opencode_beta/Dockerfile
+++ b/ha_opencode_beta/Dockerfile
@@ -51,6 +51,7 @@ ENV ADDON_CHANNEL=${ADDON_CHANNEL}
 # Install system dependencies in a single layer
 # - nodejs/npm: Required for OpenCode
 # - git: Required by OpenCode for version control operations
+# - openssh-client: Required by Git when remotes use SSH
 # - jq: JSON processing for helper scripts
 # - curl/ca-certificates: For downloading ttyd
 # - bzip2: Required by system tar to extract OpenChamber voice models
@@ -67,6 +68,7 @@ RUN apt-get update \
         git \
         jq \
         nodejs \
+        openssh-client \
         npm \
         procps \
         python3 \

--- a/ha_opencode_beta/Dockerfile
+++ b/ha_opencode_beta/Dockerfile
@@ -51,7 +51,7 @@ ENV ADDON_CHANNEL=${ADDON_CHANNEL}
 # Install system dependencies in a single layer
 # - nodejs/npm: Required for OpenCode
 # - git: Required by OpenCode for version control operations
-# - openssh-client: Required by Git when remotes use SSH
+# - openssh-client: Provides ssh, ssh-keygen, and ssh-keyscan for Git SSH remotes
 # - jq: JSON processing for helper scripts
 # - curl/ca-certificates: For downloading ttyd
 # - bzip2: Required by system tar to extract OpenChamber voice models
@@ -74,6 +74,9 @@ RUN apt-get update \
         python3 \
         python3-venv \
         tmux \
+    && command -v ssh >/dev/null \
+    && command -v ssh-keygen >/dev/null \
+    && command -v ssh-keyscan >/dev/null \
     && rm -rf /var/lib/apt/lists/*
 
 # Chromium path for puppeteer-core (used by screenshot MCP tool)

--- a/ha_opencode_beta/test/runtime-contract.test.js
+++ b/ha_opencode_beta/test/runtime-contract.test.js
@@ -79,6 +79,13 @@ describe(`${CHANNEL} runtime pin`, () => {
       /opencode_certified_version\(\)/,
     );
   });
+
+  it("ships OpenSSH client tools for Git SSH remotes", () => {
+    assert.match(dockerfile, /^\s*openssh-client \\/m);
+    for (const command of ["ssh", "ssh-keygen", "ssh-keyscan"]) {
+      assert.match(dockerfile, new RegExp(`command -v ${command} >/dev/null`));
+    }
+  });
 });
 
 describe(`${CHANNEL} bundled runtime precedence`, () => {


### PR DESCRIPTION
## Summary

- add `openssh-client` to both stable and beta images
- verify `ssh`, `ssh-keygen`, and `ssh-keyscan` are available during the image build
- add runtime contract coverage for the OpenSSH client tools

## Motivation

Git is already included for version control operations, but Git remotes using SSH require the OpenSSH client to be available in the runtime.

Including `openssh-client` makes SSH-based Git remotes work without requiring transient package installation inside a running add-on.

## Validation

- stable runtime contract tests pass
- beta runtime contract tests pass
- stable and beta changes are kept in parity
- `git diff --check` passes