### PR TITLE
harden: sanitize child_process call in opencode-smoke-probe.mjs...

### DIFF
--- a/ha_opencode/rootfs/usr/local/bin/opencode-smoke-probe.mjs
+++ b/ha_opencode/rootfs/usr/local/bin/opencode-smoke-probe.mjs
@@ -22,6 +22,12 @@ const MCP_SERVER = process.env.SMOKE_PROBE_MCP || "/opt/ha-mcp-server/index.js";
 const LSP_SERVER = process.env.SMOKE_PROBE_LSP || "/opt/ha-lsp-server/server.js";
 
 function withChild(command, args, env, drive) {
+  // Only ever spawn the current, trusted Node binary: this closes off any
+  // possibility of command injection even if a future caller passes an
+  // untrusted `command` value.
+  if (command !== process.execPath) {
+    throw new Error(`withChild: refusing to spawn untrusted command ${command}`);
+  }
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       env: { ...process.env, ...env },


### PR DESCRIPTION
## Summary
Harden input handling in `ha_opencode/rootfs/usr/local/bin/opencode-smoke-probe.mjs` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `ha_opencode/rootfs/usr/local/bin/opencode-smoke-probe.mjs:26` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `command`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Changes
- `ha_opencode/rootfs/usr/local/bin/opencode-smoke-probe.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
